### PR TITLE
Feature/bugfix loop closure

### DIFF
--- a/voxgraph/src/frontend/voxgraph_mapper.cpp
+++ b/voxgraph/src/frontend/voxgraph_mapper.cpp
@@ -271,8 +271,6 @@ void VoxgraphMapper::loopClosureCallback(
   if (!success_A || !success_B) {
     ROS_WARN_STREAM(warning_msg_prefix.str() << ": timestamp A or B has no "
                                                 "corresponding submap");
-    ROS_INFO("[VoxgraphMapper] timestamp A: %d, timestamp B: %d",
-        submap_id_A, submap_id_B);
     return;
   }
   if (submap_id_A == submap_id_B) {


### PR DESCRIPTION
When loop closing submap 0, the submap lookup was considered to be unsuccessful
Added bool variable of succes for time lookup