### PR TITLE
Finish submap function is now a declared in submap base classes.

### DIFF
--- a/voxgraph/include/voxgraph/frontend/submap_collection/voxgraph_submap.h
+++ b/voxgraph/include/voxgraph/frontend/submap_collection/voxgraph_submap.h
@@ -54,7 +54,7 @@ class VoxgraphSubmap : public cblox::TsdfEsdfSubmap {
 
   // Indicate that the submap is finished and generate all cached members
   // NOTE: These cached members are mainly used in the registration cost funcs
-  void finishSubmap();
+  virtual void finishSubmap() override;
 
   void transformSubmap(const voxblox::Transformation& T_new_old);
 


### PR DESCRIPTION
This function is now needed in cblox for the planning stuff. It has become part of the whole class hierarchy and is therefore now virtual. 