### PR TITLE
Updated load from stream to reflect cblox changes.

### DIFF
--- a/voxgraph/include/voxgraph/frontend/submap_collection/voxgraph_submap.h
+++ b/voxgraph/include/voxgraph/frontend/submap_collection/voxgraph_submap.h
@@ -75,6 +75,12 @@ class VoxgraphSubmap : public cblox::TsdfEsdfSubmap {
   const BoxCornerMatrix getMissionFrameSurfaceAabbCorners() const;
   const BoxCornerMatrix getMissionFrameSubmapAabbCorners() const;
 
+  // Load a submap from stream.
+  // Note: Returns a nullptr if load is unsuccessful.
+  static VoxgraphSubmap::Ptr LoadFromStream(const Config& config,
+                                            std::fstream* proto_file_ptr,
+                                            uint64_t* tmp_byte_offset_ptr);
+
  private:
   typedef Eigen::Matrix<voxblox::FloatingPoint, 4, 8> HomogBoxCornerMatrix;
   using TsdfVoxel = voxblox::TsdfVoxel;

--- a/voxgraph/src/frontend/submap_collection/voxgraph_submap.cpp
+++ b/voxgraph/src/frontend/submap_collection/voxgraph_submap.cpp
@@ -384,4 +384,24 @@ const BoxCornerMatrix VoxgraphSubmap::getMissionFrameSubmapAabbCorners() const {
   // of the full submap's AABB
   return getMissionFrameSubmapAabb().getCornerCoordinates();
 }
+
+VoxgraphSubmap::Ptr VoxgraphSubmap::LoadFromStream(
+    const Config& config, std::fstream* proto_file_ptr,
+    uint64_t* tmp_byte_offset_ptr) {
+  // Note(alexmillane): There is no difference (for now) between the information
+  // loaded in a VoxgraphSubmap and a TsdfEsdfSubmap. Therefore we just load the
+  // later and copy over the data.
+  TsdfEsdfSubmap::Ptr tsdf_esdf_submap = TsdfEsdfSubmap::LoadFromStream(
+      config, proto_file_ptr, tmp_byte_offset_ptr);
+  if (tsdf_esdf_submap == nullptr) {
+    return nullptr;
+  }
+  // Copying over
+  auto submap_ptr = std::make_shared<VoxgraphSubmap>(
+      tsdf_esdf_submap->getPose(), tsdf_esdf_submap->getID(), config);
+  submap_ptr->esdf_map_ = tsdf_esdf_submap->getEsdfMapPtr();
+  submap_ptr->tsdf_map_ = tsdf_esdf_submap->getTsdfMapPtr();
+  return submap_ptr;
+}
+
 }  // namespace voxgraph

--- a/voxgraph/src/tools/test_benches/registration_test_bench.cpp
+++ b/voxgraph/src/tools/test_benches/registration_test_bench.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include <cblox/core/submap_collection.h>
-#include <cblox/io/tsdf_submap_io.h>
+#include <cblox/io/submap_io.h>
 #include <cblox/utils/quat_transformation_protobuf_utils.h>
 #include <glog/logging.h>
 #include <ros/ros.h>


### PR DESCRIPTION
In cblox we have added static methods for loading submaps per class to avoid proliferating template specialization in the loading functions. The flip side is that we need a loading function for voxgraph submaps (before it was just using the TsdfEsdf specialization).

Depends on: ethz-asl/cblox#30