### PR TITLE
Make the mesh color modes configureable through ROS params

### DIFF
--- a/voxgraph/config/voxgraph_mapper.yaml
+++ b/voxgraph/config/voxgraph_mapper.yaml
@@ -50,4 +50,5 @@ measurements:
     information_zz: 2500.0
 
 mesh_min_weight: 2.0
-mesh_use_color: false
+submap_mesh_color_mode: "lambert_color"
+combined_mesh_color_mode: "normals"

--- a/voxgraph/include/voxgraph/tools/visualization/submap_visuals.h
+++ b/voxgraph/include/voxgraph/tools/visualization/submap_visuals.h
@@ -20,13 +20,20 @@ class SubmapVisuals {
   explicit SubmapVisuals(VoxgraphSubmap::Config submap_config,
                          voxblox::MeshIntegratorConfig mesh_config);
 
+  // TODO(victorr): Use a Config with fromRosParams(...) method that is passed
+  //                to the constructor method instead
   void setMeshOpacity(float mesh_opacity) { mesh_opacity_ = mesh_opacity; }
+  void setSubmapMeshColorMode(voxblox::ColorMode color_mode) {
+    submap_mesh_color_mode_ = color_mode;
+  }
+  void setCombinedMeshColorMode(voxblox::ColorMode color_mode) {
+    combined_mesh_color_mode_ = color_mode;
+  }
 
   void publishMesh(const voxblox::MeshLayer::Ptr& mesh_layer_ptr,
                    const std::string& submap_frame,
                    const ros::Publisher& publisher,
-                   const voxblox::ColorMode& color_mode =
-                       voxblox::ColorMode::kLambertColor) const;
+                   const voxblox::ColorMode& color_mode) const;
 
   void publishMesh(
       const cblox::SubmapCollection<VoxgraphSubmap>& submap_collection,
@@ -64,6 +71,8 @@ class SubmapVisuals {
   std::unique_ptr<cblox::SubmapMesher> combined_submap_mesher_;
 
   float mesh_opacity_;
+  voxblox::ColorMode combined_mesh_color_mode_;
+  voxblox::ColorMode submap_mesh_color_mode_;
 };
 }  // namespace voxgraph
 

--- a/voxgraph/src/frontend/voxgraph_mapper.cpp
+++ b/voxgraph/src/frontend/voxgraph_mapper.cpp
@@ -349,11 +349,10 @@ void VoxgraphMapper::publishActiveSubmapMeshCallback() {
   if (active_mesh_pub_.getNumSubscribers() > 0) {
     cblox::SubmapID active_submap_id =
         submap_collection_ptr_->getActiveSubmapID();
+    const voxblox::ExponentialOffsetColorMap submap_id_color_map;
     submap_vis_.publishMesh(
         *submap_collection_ptr_, active_submap_id,
-        voxblox::rainbowColorMap(
-            static_cast<double>(active_submap_id) /
-            static_cast<double>(cblox::kDefaultColorCycleLength)),
+        submap_id_color_map.colorLookup(active_submap_id),
         map_tracker_.getFrameNames().output_active_submap_frame,
         active_mesh_pub_);
   }

--- a/voxgraph/src/frontend/voxgraph_mapper.cpp
+++ b/voxgraph/src/frontend/voxgraph_mapper.cpp
@@ -91,9 +91,12 @@ void VoxgraphMapper::getParametersFromRos() {
         ros::Duration(update_mesh_every_n_sec),
         std::bind(&VoxgraphMapper::publishActiveSubmapMeshCallback, this));
   }
-  float mesh_opacity = 1.0;
-  nh_private_.param("mesh_opacity", mesh_opacity, mesh_opacity);
-  submap_vis_.setMeshOpacity(mesh_opacity);
+  submap_vis_.setMeshOpacity(nh_private_.param("mesh_opacity", 1.0));
+  submap_vis_.setSubmapMeshColorMode(
+      voxblox::getColorModeFromString(nh_private_.param<std::string>(
+          "submap_mesh_color_mode", "lambert_color")));
+  submap_vis_.setCombinedMeshColorMode(voxblox::getColorModeFromString(
+      nh_private_.param<std::string>("combined_mesh_color_mode", "normals")));
 
   // Read whether or not to auto pause the rosbag during graph optimization
   nh_private_.param("auto_pause_rosbag", auto_pause_rosbag_,

--- a/voxgraph/src/tools/visualization/submap_visuals.cpp
+++ b/voxgraph/src/tools/visualization/submap_visuals.cpp
@@ -13,15 +13,15 @@
 namespace voxgraph {
 SubmapVisuals::SubmapVisuals(VoxgraphSubmap::Config submap_config,
                              voxblox::MeshIntegratorConfig mesh_config)
-    : mesh_config_(std::move(mesh_config)), mesh_opacity_(1.0) {
+    : mesh_config_(mesh_config), mesh_opacity_(1.0) {
   // Meshing params from ROS params server
   // NOTE(alexmillane): The separated mesher *requires* color, so this is
   //                    hard-coded.
   combined_submap_mesher_.reset(
-      new cblox::SubmapMesher(std::move(submap_config), mesh_config_));
+      new cblox::SubmapMesher(submap_config, mesh_config_));
   mesh_config_.use_color = true;
   separated_submap_mesher_.reset(
-      new cblox::SubmapMesher(std::move(submap_config), mesh_config_));
+      new cblox::SubmapMesher(submap_config, mesh_config_));
 }
 
 void SubmapVisuals::publishMesh(const voxblox::MeshLayer::Ptr& mesh_layer_ptr,
@@ -62,7 +62,7 @@ void SubmapVisuals::publishMesh(
   separated_submap_mesher_->colorMeshLayer(submap_color, mesh_layer_ptr.get());
 
   // Publish mesh
-  publishMesh(mesh_layer_ptr, submap_frame, publisher);
+  publishMesh(mesh_layer_ptr, submap_frame, publisher, submap_mesh_color_mode_);
 }
 
 void SubmapVisuals::publishSeparatedMesh(
@@ -72,7 +72,8 @@ void SubmapVisuals::publishSeparatedMesh(
       std::make_shared<cblox::MeshLayer>(submap_collection.block_size());
   separated_submap_mesher_->generateSeparatedMesh(submap_collection,
                                                   mesh_layer_ptr.get());
-  publishMesh(mesh_layer_ptr, mission_frame, publisher);
+  publishMesh(mesh_layer_ptr, mission_frame, publisher,
+              submap_mesh_color_mode_);
 }
 
 void SubmapVisuals::publishCombinedMesh(
@@ -83,7 +84,7 @@ void SubmapVisuals::publishCombinedMesh(
   combined_submap_mesher_->generateCombinedMesh(submap_collection,
                                                 mesh_layer_ptr.get());
   publishMesh(mesh_layer_ptr, mission_frame, publisher,
-              voxblox::ColorMode::kNormals);
+              combined_mesh_color_mode_);
 }
 
 void SubmapVisuals::saveSeparatedMesh(


### PR DESCRIPTION
The color mode for individual submap meshes can now be configured through the `submap_mesh_color_mode` ROS param, and the color mode for the combined mesh through `combined_mesh_color_mode`.

The different color mode options are [defined in voxblox here](https://github.com/ethz-asl/voxblox/blob/master/voxblox_ros/include/voxblox_ros/mesh_vis.h#L57). At the moment of writing they are: "color", "height", "normals", "lambert", and "lambert_color".