### PR TITLE
Fix/static linker error

### DIFF
--- a/voxgraph/src/tools/data_servers/loop_closure_edge_server.cpp
+++ b/voxgraph/src/tools/data_servers/loop_closure_edge_server.cpp
@@ -5,6 +5,10 @@
 #include "voxgraph/common.h"
 
 namespace voxgraph {
+
+constexpr bool LoopClosureEdgeServer::kFake6dofTransforms;
+constexpr double LoopClosureEdgeServer::kSetUnknownCovarianceEntriesTo;
+
 LoopClosureEdgeServer::LoopClosureEdgeServer(ros::NodeHandle nh_private,
                                              bool verbose)
     : verbose_(verbose) {


### PR DESCRIPTION
@victorreijgwart  Fixed the static member linker error.
The reason for is that inline static variable definition is only allowed in C++17 or after (similar to normal static members), whereas your cmakelists contains std=c++11. Depending on the compiler optimization, it might however auto-generate these or maybe you have some other specifications for your build, this is potentially why it didn't show up on your machine. Anyway, I added the standard c++11 definition to the .cpp. [Cf](https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char).