### PR TITLE
Fix missing return gcc-8

### DIFF
--- a/voxgraph/src/frontend/submap_collection/voxgraph_submap.cpp
+++ b/voxgraph/src/frontend/submap_collection/voxgraph_submap.cpp
@@ -137,6 +137,8 @@ const WeightedSampler<RegistrationPoint>& VoxgraphSubmap::getRegistrationPoints(
       return relevant_voxels_;
     case RegistrationPointType::kIsosurfacePoints:
       return isosurface_vertices_;
+    default:
+      __builtin_unreachable();
   }
 }
 


### PR DESCRIPTION
Switch case that covers all enums no longer counts as a guaranteed return, so gcc 8 complains about a missing return on a non-void function. This can be fixed by annotating that the default case is unreachable with `__builtin_unreachable()`.


See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87951 for more info.