### PR TITLE
Buffer loop closure message ahead of current timeline, and process them when new submaps are received

### DIFF
--- a/voxgraph/config/voxgraph_mapper.yaml
+++ b/voxgraph/config/voxgraph_mapper.yaml
@@ -1,4 +1,4 @@
-verbose: true
+verbose: false
 debug: true
 auto_pause_rosbag: false
 

--- a/voxgraph/config/voxgraph_mapper.yaml
+++ b/voxgraph/config/voxgraph_mapper.yaml
@@ -4,6 +4,7 @@ auto_pause_rosbag: false
 
 submap_creation_interval: 10
 loop_closure_topic_queue_length: 1000
+future_loop_closure_queue_length: 10
 submap_topic_queue_length: 10
 publisher_queue_length: 10
 

--- a/voxgraph/config/voxgraph_mapper.yaml
+++ b/voxgraph/config/voxgraph_mapper.yaml
@@ -1,4 +1,4 @@
-verbose: false
+verbose: true
 debug: true
 auto_pause_rosbag: false
 
@@ -51,6 +51,14 @@ measurements:
   height:
     enabled: false
     information_zz: 2500.0
+  loop_closure:
+    enabled: true
+    information_matrix:
+      x_x:     100.0
+      y_y:     100.0
+      z_z:     250.0
+      yaw_yaw: 250.0
+
 
 mesh_min_weight: 2.0
 submap_mesh_color_mode: "lambert_color"

--- a/voxgraph/include/voxgraph/frontend/voxgraph_mapper.h
+++ b/voxgraph/include/voxgraph/frontend/voxgraph_mapper.h
@@ -1,6 +1,7 @@
 #ifndef VOXGRAPH_FRONTEND_VOXGRAPH_MAPPER_H_
 #define VOXGRAPH_FRONTEND_VOXGRAPH_MAPPER_H_
 
+#include <deque>
 #include <future>
 #include <memory>
 #include <string>
@@ -156,6 +157,17 @@ class VoxgraphMapper {
   // TODO(victorr): Deprecate the MapTracker
   MapTracker map_tracker_;
   Transformation T_odom__previous_submap_;
+
+  std::deque<voxgraph_msgs::LoopClosure> future_loop_closure_queue_;
+  int future_loop_closure_queue_length_;
+  void addFutureLoopClosure(const voxgraph_msgs::LoopClosure& loop_closure_msg);
+  void processFutureLoopClosure();
+  inline bool isTimeInFuture(const ros::Time& timestamp) {
+    return timestamp >
+           submap_collection_ptr_
+               ->getSubmapConstPtr(submap_collection_ptr_->getLastSubmapId())
+               ->getEndTime();
+  }
 };
 }  // namespace voxgraph
 

--- a/voxgraph/include/voxgraph/frontend/voxgraph_mapper.h
+++ b/voxgraph/include/voxgraph/frontend/voxgraph_mapper.h
@@ -165,12 +165,13 @@ class VoxgraphMapper {
   void addFutureLoopClosure(const voxgraph_msgs::LoopClosure& loop_closure_msg);
   void processFutureLoopClosure();
   inline bool isTimeInFuture(const ros::Time& timestamp) {
-    return timestamp >
-           submap_collection_ptr_
-               ->getSubmapConstPtr(submap_collection_ptr_->getLastSubmapId())
-               ->getEndTime();
+    SubmapID submap_id;
+    return !submap_collection_ptr_->lookupActiveSubmapByTime(timestamp,
+                                                             &submap_id);
   }
-  constexpr static int kMaxNLcNotCatched = 2;
+  bool addLoopClosureMesurement(
+      const voxgraph_msgs::LoopClosure& loop_closure_msg);
+  constexpr static int kMaxNotCatched = 2;
 };
 }  // namespace voxgraph
 

--- a/voxgraph/include/voxgraph/frontend/voxgraph_mapper.h
+++ b/voxgraph/include/voxgraph/frontend/voxgraph_mapper.h
@@ -5,6 +5,7 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -158,7 +159,8 @@ class VoxgraphMapper {
   MapTracker map_tracker_;
   Transformation T_odom__previous_submap_;
 
-  std::deque<voxgraph_msgs::LoopClosure> future_loop_closure_queue_;
+  std::deque<std::pair<voxgraph_msgs::LoopClosure, int>>
+      future_loop_closure_queue_;
   int future_loop_closure_queue_length_;
   void addFutureLoopClosure(const voxgraph_msgs::LoopClosure& loop_closure_msg);
   void processFutureLoopClosure();
@@ -168,6 +170,7 @@ class VoxgraphMapper {
                ->getSubmapConstPtr(submap_collection_ptr_->getLastSubmapId())
                ->getEndTime();
   }
+  constexpr static int kMaxNLcNotCatched = 2;
 };
 }  // namespace voxgraph
 

--- a/voxgraph/src/frontend/voxgraph_mapper.cpp
+++ b/voxgraph/src/frontend/voxgraph_mapper.cpp
@@ -463,6 +463,8 @@ bool VoxgraphMapper::finishMapCallback(std_srvs::Empty::Request& request,
     pose_graph_interface_.updateRegistrationConstraints();
   }
 
+  processFutureLoopClosure();
+
   // Optimize the pose graph
   optimizePoseGraph();
 


### PR DESCRIPTION
If newly received loop closure message happens ahead of current submap timelines, it will be saved, and processed when new submaps are received. Loop closure messages will be deleted if their timestamps are still not catched after a number of new submaps received.
![Screenshot from 2020-10-21 13-31-08](https://user-images.githubusercontent.com/15899704/96677239-c6266700-13a1-11eb-97c9-a4caa9b07123.png)
![Screenshot from 2020-10-21 13-31-42](https://user-images.githubusercontent.com/15899704/96677249-c7f02a80-13a1-11eb-8e56-bcd4fe5e7e4f.png)
